### PR TITLE
Change view to get members from DB

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -17,9 +17,13 @@
         font-size: 20px;
         color: #333;
       }
-      &__members {
+      ul.main__header__group__members {
         font-size: 12px;
         color: $gray-fontcolor;
+        display: flex;
+        li.main__header__group__members__member{
+          padding-left: 6px;
+        }
       }
     }
     &__editbutton {

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -16,8 +16,11 @@
       .main__header__group
         .main__header__group__name
           テストグループ
-        .main__header__group__members
-          Members: test ichiro 田中義雄
+        %ul.main__header__group__members
+          Members:
+          - @group.users.each do |user|
+            %li.main__header__group__members__member
+              #{user.name}
       = link_to "Edit", "#", class: "main__header__editbutton"
     .main__content
       -# チャットのダミーを挿入


### PR DESCRIPTION
# WHAT
実装漏れしていた、グループのメンバー名をDBから取得する処理を実装
# WHY
サービスに必須であるため