### PR TITLE
Fix link-path with icons

### DIFF
--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,9 +4,9 @@
       .sidebar__user__content
         .sidebar__user__content__name
           = current_user.name
-        = link_to "users/:id/edit", class: "sidebar__icon" do
+        = link_to edit_user_url(current_user), class: "sidebar__icon" do
           = fa_icon 'cog'
-        = link_to "groups/new", class: "sidebar__icon" do
+        = link_to new_group_url, class: "sidebar__icon" do
           = fa_icon 'edit'
     / グループ情報を挿入
     = render partial: "shared/group"


### PR DESCRIPTION
# WHAT
リンク先に指定されているパスを直書きから名前付きルーティングに変更
#WHY
絶対パスを使用するため